### PR TITLE
Fix up args & add --debug

### DIFF
--- a/MetasploitMCP.py
+++ b/MetasploitMCP.py
@@ -1704,13 +1704,6 @@ def find_available_port(start_port, host='127.0.0.1', max_attempts=10):
     return start_port
 
 if __name__ == "__main__":
-    # Initialize MSF Client - Critical for server function
-    try:
-        initialize_msf_client()
-    except (ValueError, ConnectionError, RuntimeError) as e:
-        logger.critical(f"CRITICAL: Failed to initialize Metasploit client on startup: {e}. Server cannot function.")
-        sys.exit(1) # Exit if MSF connection fails at start
-
     # --- Setup argument parser for transport mode and server configuration ---
     import argparse
     
@@ -1726,6 +1719,13 @@ if __name__ == "__main__":
     parser.add_argument('--reload', action='store_true', help='Enable auto-reload (for development)')
     parser.add_argument('--find-port', action='store_true', help='Force finding an available port starting from --port or 8085')
     args = parser.parse_args()
+
+    # Initialize MSF Client - Critical for server function
+    try:
+        initialize_msf_client()
+    except (ValueError, ConnectionError, RuntimeError) as e:
+        logger.critical(f"CRITICAL: Failed to initialize Metasploit client on startup: {e}. Server cannot function.")
+        sys.exit(1) # Exit if MSF connection fails at start
 
     if args.transport == 'stdio':
         logger.info("Starting MCP server in STDIO transport mode.")

--- a/MetasploitMCP.py
+++ b/MetasploitMCP.py
@@ -24,19 +24,21 @@ from starlette.routing import Mount, Route, Router
 
 # --- Configuration & Constants ---
 
-logging.basicConfig(
-    level=os.environ.get("LOG_LEVEL", "INFO").upper(),
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger("metasploit_mcp_server")
-session_shell_type: Dict[str, str] = {}
-
 # Metasploit Connection Config (from environment variables)
 MSF_PASSWORD = os.getenv('MSF_PASSWORD', 'yourpassword')
 MSF_SERVER = os.getenv('MSF_SERVER', '127.0.0.1')
 MSF_PORT_STR = os.getenv('MSF_PORT', '55553')
 MSF_SSL_STR = os.getenv('MSF_SSL', 'false')
-PAYLOAD_SAVE_DIR = os.environ.get('PAYLOAD_SAVE_DIR', str(pathlib.Path.home() / "payloads"))
+PAYLOAD_SAVE_DIR = os.getenv('PAYLOAD_SAVE_DIR', str(pathlib.Path.home() / "payloads"))
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'info')
+
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+)
+logger = logging.getLogger("metasploit_mcp_server")
+logger.setLevel(LOG_LEVEL.upper())
+
+session_shell_type: Dict[str, str] = {}
 
 # Timeouts and Polling Intervals (in seconds)
 DEFAULT_CONSOLE_READ_TIMEOUT = 15  # Default for quick console commands
@@ -1718,7 +1720,12 @@ if __name__ == "__main__":
     parser.add_argument('--port', type=int, default=None, help='Port to listen on (default: find available from 8085)')
     parser.add_argument('--reload', action='store_true', help='Enable auto-reload (for development)')
     parser.add_argument('--find-port', action='store_true', help='Force finding an available port starting from --port or 8085')
+    parser.add_argument('--debug', action='store_true', help='Make output more verbose')
     args = parser.parse_args()
+
+    if args.debug:
+        LOG_LEVEL = 'debug'
+        logger.setLevel(LOG_LEVEL.upper())
 
     # Initialize MSF Client - Critical for server function
     try:
@@ -1756,5 +1763,5 @@ if __name__ == "__main__":
             host=args.host,
             port=selected_port,
             reload=args.reload,
-            log_level="info"
+            log_level=LOG_LEVEL.lower()
         )

--- a/MetasploitMCP.py
+++ b/MetasploitMCP.py
@@ -37,6 +37,12 @@ logging.basicConfig(
 )
 logger = logging.getLogger("metasploit_mcp_server")
 logger.setLevel(LOG_LEVEL.upper())
+logger.debug(f"MSF_PASSWORD    : {MSF_PASSWORD}")
+logger.debug(f"MSF_SERVER      : {MSF_SERVER}")
+logger.debug(f"MSF_PORT_STR    : {MSF_PORT_STR}")
+logger.debug(f"MSF_SSL_STR     : {MSF_SSL_STR}")
+logger.debug(f"PAYLOAD_SAVE_DIR: {PAYLOAD_SAVE_DIR}")
+logger.debug(f"LOG_LEVEL       : {LOG_LEVEL}")
 
 session_shell_type: Dict[str, str] = {}
 


### PR DESCRIPTION
**Before**:

```console
$ python3 MetasploitMCP.py --help
2026-02-05 10:22:10,971 - metasploit_mcp_server - INFO - Attempting to initialize Metasploit RPC client...
2026-02-05 10:22:10,973 - retry.api - WARNING - HTTPConnectionPool(host='127.0.0.1', port=55553): Max retries exceeded with url: /api/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f74ad2cc440>: Failed to establish a new connection: [Errno 111] Connection refused')), retrying in 1 seconds...
2026-02-05 10:22:11,974 - retry.api - WARNING - HTTPConnectionPool(host='127.0.0.1', port=55553): Max retries exceeded with url: /api/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f74ad2d4410>: Failed to establish a new connection: [Errno 111] Connection refused')), retrying in 2 seconds...
2026-02-05 10:22:13,975 - metasploit_mcp_server - ERROR - An unexpected error occurred during MSF client initialization: HTTPConnectionPool(host='127.0.0.1', port=55553): Max retries exceeded with url: /api/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f74ad2d4cd0>: Failed to establish a new connection: [Errno 111] Connection refused'))
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 198, in _new_conn
    sock = connection.create_connection(
        (self._dns_host, self.port),
    ...<2 lines>...
        socket_options=self.socket_options,
    )
  File "/usr/lib/python3/dist-packages/urllib3/util/connection.py", line 85, in create_connection
    raise err
  File "/usr/lib/python3/dist-packages/urllib3/util/connection.py", line 73, in create_connection
    sock.connect(sa)
    ~~~~~~~~~~~~^^^^
ConnectionRefusedError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
        conn,
    ...<10 lines>...
        **response_kw,
    )
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 493, in _make_request
    conn.request(
    ~~~~~~~~~~~~^
        method,
        ^^^^^^^
    ...<6 lines>...
        enforce_content_length=enforce_content_length,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 494, in request
    self.endheaders()
    ~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/http/client.py", line 1353, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/http/client.py", line 1113, in _send_output
    self.send(msg)
    ~~~~~~~~~^^^^^
  File "/usr/lib/python3.13/http/client.py", line 1057, in send
    self.connect()
    ~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 325, in connect
    self.sock = self._new_conn()
                ~~~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 213, in _new_conn
    raise NewConnectionError(
        self, f"Failed to establish a new connection: {e}"
    ) from e
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f74ad2d4cd0>: Failed to establish a new connection: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/requests/adapters.py", line 644, in send
    resp = conn.urlopen(
        method=request.method,
    ...<9 lines>...
        chunked=chunked,
    )
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 841, in urlopen
    retries = retries.increment(
        method, url, error=new_e, _pool=self, _stacktrace=sys.exc_info()[2]
    )
  File "/usr/lib/python3/dist-packages/urllib3/util/retry.py", line 519, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='127.0.0.1', port=55553): Max retries exceeded with url: /api/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f74ad2d4cd0>: Failed to establish a new connection: [Errno 111] Connection refused'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kali/metasploitmcp/MetasploitMCP.py", line 78, in initialize_msf_client
    client = MsfRpcClient(
        password=MSF_PASSWORD,
    ...<2 lines>...
        ssl=msf_ssl
    )
  File "/usr/lib/python3/dist-packages/pymetasploit3/msfrpc.py", line 205, in __init__
    self.login(kwargs.get('username', 'msf'), password)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pymetasploit3/msfrpc.py", line 253, in login
    auth = self.call(MsfRpcMethod.AuthLogin, [user, password])
  File "/usr/lib/python3/dist-packages/pymetasploit3/msfrpc.py", line 239, in call
    r = self.post_request(url, payload)
  File "/usr/lib/python3/dist-packages/decorator.py", line 235, in fun
    return caller(func, *(extras + args), **kw)
  File "/usr/lib/python3/dist-packages/retry/api.py", line 73, in retry_decorator
    return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
                            logger)
  File "/usr/lib/python3/dist-packages/retry/api.py", line 33, in __retry_internal
    return f()
  File "/usr/lib/python3/dist-packages/pymetasploit3/msfrpc.py", line 250, in post_request
    return requests.post(url, data=payload, headers=self.headers, verify=False)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/requests/api.py", line 115, in post
    return request("post", url, data=data, json=json, **kwargs)
  File "/usr/lib/python3/dist-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3/dist-packages/requests/adapters.py", line 677, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='127.0.0.1', port=55553): Max retries exceeded with url: /api/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f74ad2d4cd0>: Failed to establish a new connection: [Errno 111] Connection refused'))
2026-02-05 10:22:13,979 - metasploit_mcp_server - CRITICAL - CRITICAL: Failed to initialize Metasploit client on startup: Unexpected error initializing MSF client: HTTPConnectionPool(host='127.0.0.1', port=55553): Max retries exceeded with url: /api/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f74ad2d4cd0>: Failed to establish a new connection: [Errno 111] Connection refused')). Server cannot function.
$
```

**After**:
```console
$ python3 MetasploitMCP.py --help
usage: MetasploitMCP.py [-h] [--transport {http,stdio}] [--host HOST] [--port PORT] [--reload] [--find-port] [--debug]

Run Streamlined Metasploit MCP Server

options:
  -h, --help            show this help message and exit
  --transport {http,stdio}
                        MCP transport mode to use (http=SSE, stdio=direct pipe)
  --host HOST           Host to bind the HTTP server to (default: 127.0.0.1)
  --port PORT           Port to listen on (default: find available from 8085)
  --reload              Enable auto-reload (for development)
  --find-port           Force finding an available port starting from --port or 8085
  --debug               Make output more verbose
$
```